### PR TITLE
refactor: use package-relative open_webui imports

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -1,7 +1,11 @@
 import base64
 import os
 import random
+import sys
 from pathlib import Path
+
+sys.modules.setdefault("open_webui", sys.modules[__name__])
+sys.modules.setdefault("backend.open_webui", sys.modules[__name__])
 
 import typer
 import uvicorn

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -16,7 +16,7 @@ from sqlalchemy import JSON, Column, DateTime, Integer, func
 from authlib.integrations.starlette_client import OAuth
 
 
-from backend.open_webui.env import (
+from open_webui.env import (
     DATA_DIR,
     DATABASE_URL,
     ENV,
@@ -32,8 +32,8 @@ from backend.open_webui.env import (
     WEBUI_NAME,
     log,
 )
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.utils.redis import get_redis_connection
+from open_webui.internal.db import Base, get_db
+from open_webui.utils.redis import get_redis_connection
 
 
 class EndpointFilter(logging.Filter):

--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -19,34 +19,34 @@ from fastapi import (
 from starlette.responses import Response, StreamingResponse
 
 
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.socket.main import (
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.socket.main import (
     get_event_call,
     get_event_emitter,
 )
 
 
-from backend.open_webui.models.users import UserModel
-from backend.open_webui.models.functions import Functions
-from backend.open_webui.models.models import Models
+from open_webui.models.users import UserModel
+from open_webui.models.functions import Functions
+from open_webui.models.models import Models
 
-from backend.open_webui.utils.plugin import (
+from open_webui.utils.plugin import (
     load_function_module_by_id,
     get_function_module_from_cache,
 )
-from backend.open_webui.utils.tools import get_tools
-from backend.open_webui.utils.access_control import has_access
+from open_webui.utils.tools import get_tools
+from open_webui.utils.access_control import has_access
 
-from backend.open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
+from open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
 
-from backend.open_webui.utils.misc import (
+from open_webui.utils.misc import (
     add_or_update_system_message,
     get_last_user_message,
     prepend_to_first_user_message_content,
     openai_chat_chunk_message_template,
     openai_chat_completion_message_template,
 )
-from backend.open_webui.utils.payload import (
+from open_webui.utils.payload import (
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
 )

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -4,8 +4,8 @@ import logging
 from contextlib import contextmanager
 from typing import Any, Optional
 
-from backend.open_webui.internal.wrappers import register_connection
-from backend.open_webui.env import (
+from open_webui.internal.wrappers import register_connection
+from open_webui.env import (
     OPEN_WEBUI_DIR,
     DATABASE_URL,
     DATABASE_SCHEMA,

--- a/backend/open_webui/internal/migrations/010_migrate_modelfiles_to_models.py
+++ b/backend/open_webui/internal/migrations/010_migrate_modelfiles_to_models.py
@@ -30,7 +30,7 @@ import peewee as pw
 from peewee_migrate import Migrator
 import json
 
-from backend.open_webui.utils.misc import parse_ollama_modelfile
+from open_webui.utils.misc import parse_ollama_modelfile
 
 with suppress(ImportError):
     import playhouse.postgres_ext as pw_pext

--- a/backend/open_webui/internal/wrappers.py
+++ b/backend/open_webui/internal/wrappers.py
@@ -2,7 +2,7 @@ import logging
 import os
 from contextvars import ContextVar
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 from peewee import *
 from peewee import InterfaceError as PeeWeeInterfaceError
 from peewee import PostgresqlDatabase

--- a/backend/open_webui/migrations/env.py
+++ b/backend/open_webui/migrations/env.py
@@ -1,8 +1,8 @@
 from logging.config import fileConfig
 
 from alembic import context
-from backend.open_webui.models.auths import Auth
-from backend.open_webui.env import DATABASE_URL, DATABASE_PASSWORD
+from open_webui.models.auths import Auth
+from open_webui.env import DATABASE_URL, DATABASE_PASSWORD
 from sqlalchemy import engine_from_config, pool, create_engine
 
 # this is the Alembic Config object, which provides

--- a/backend/open_webui/migrations/versions/7e5b5dc7342b_init.py
+++ b/backend/open_webui/migrations/versions/7e5b5dc7342b_init.py
@@ -11,9 +11,9 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-import backend.open_webui.internal.db
-from backend.open_webui.internal.db import JSONField
-from backend.open_webui.migrations.util import get_existing_tables
+import open_webui.internal.db
+from open_webui.internal.db import JSONField
+from open_webui.migrations.util import get_existing_tables
 
 # revision identifiers, used by Alembic.
 revision: str = "7e5b5dc7342b"

--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -2,12 +2,12 @@ import logging
 import uuid
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.models.users import UserModel, Users
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.internal.db import Base, get_db
+from open_webui.models.users import UserModel, Users
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, String, Text
-from backend.open_webui.utils.auth import verify_password
+from open_webui.utils.auth import verify_password
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/open_webui/models/channels.py
+++ b/backend/open_webui/models/channels.py
@@ -3,8 +3,8 @@ import time
 import uuid
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.utils.access_control import has_access
+from open_webui.internal.db import Base, get_db
+from open_webui.utils.access_control import has_access
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Boolean, Column, String, Text, JSON

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -4,10 +4,10 @@ import time
 import uuid
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.models.tags import TagModel, Tag, Tags
-from backend.open_webui.models.folders import Folders
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.internal.db import Base, get_db
+from open_webui.models.tags import TagModel, Tag, Tags
+from open_webui.models.folders import Folders
+from open_webui.env import SRC_LOG_LEVELS
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Boolean, Column, String, Text, JSON, Index

--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -3,10 +3,10 @@ import time
 import uuid
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.models.chats import Chats
+from open_webui.internal.db import Base, get_db
+from open_webui.models.chats import Chats
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, Text, JSON, Boolean
 

--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -2,8 +2,8 @@ import logging
 import time
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, JSONField, get_db
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.internal.db import Base, JSONField, get_db
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, Text, JSON
 

--- a/backend/open_webui/models/folders.py
+++ b/backend/open_webui/models/folders.py
@@ -8,8 +8,8 @@ import re
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, Text, JSON, Boolean, func
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.internal.db import Base, get_db
+from open_webui.env import SRC_LOG_LEVELS
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -2,9 +2,9 @@ import logging
 import time
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, JSONField, get_db
-from backend.open_webui.models.users import Users
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.internal.db import Base, JSONField, get_db
+from open_webui.models.users import Users
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Boolean, Column, String, Text, Index
 

--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -4,10 +4,10 @@ import time
 from typing import Optional
 import uuid
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.internal.db import Base, get_db
+from open_webui.env import SRC_LOG_LEVELS
 
-from backend.open_webui.models.files import FileMetadataResponse
+from open_webui.models.files import FileMetadataResponse
 
 
 from pydantic import BaseModel, ConfigDict

--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -4,18 +4,18 @@ import time
 from typing import Optional
 import uuid
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.internal.db import Base, get_db
+from open_webui.env import SRC_LOG_LEVELS
 
-from backend.open_webui.models.files import FileMetadataResponse
-from backend.open_webui.models.groups import Groups
-from backend.open_webui.models.users import Users, UserResponse
+from open_webui.models.files import FileMetadataResponse
+from open_webui.models.groups import Groups
+from open_webui.models.users import Users, UserResponse
 
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, Text, JSON
 
-from backend.open_webui.utils.access_control import has_access
+from open_webui.utils.access_control import has_access
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/open_webui/models/memories.py
+++ b/backend/open_webui/models/memories.py
@@ -2,7 +2,7 @@ import time
 import uuid
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, get_db
+from open_webui.internal.db import Base, get_db
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, Text
 

--- a/backend/open_webui/models/messages.py
+++ b/backend/open_webui/models/messages.py
@@ -3,8 +3,8 @@ import time
 import uuid
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.models.tags import TagModel, Tag, Tags
+from open_webui.internal.db import Base, get_db
+from open_webui.models.tags import TagModel, Tag, Tags
 
 
 from pydantic import BaseModel, ConfigDict

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -2,11 +2,11 @@ import logging
 import time
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, JSONField, get_db
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.internal.db import Base, JSONField, get_db
+from open_webui.env import SRC_LOG_LEVELS
 
-from backend.open_webui.models.groups import Groups
-from backend.open_webui.models.users import Users, UserResponse
+from open_webui.models.groups import Groups
+from open_webui.models.users import Users, UserResponse
 
 
 from pydantic import BaseModel, ConfigDict
@@ -16,7 +16,7 @@ from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy import BigInteger, Column, Text, JSON, Boolean
 
 
-from backend.open_webui.utils.access_control import has_access
+from open_webui.utils.access_control import has_access
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/models/notes.py
+++ b/backend/open_webui/models/notes.py
@@ -4,10 +4,10 @@ import uuid
 from typing import Optional
 from functools import lru_cache
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.models.groups import Groups
-from backend.open_webui.utils.access_control import has_access
-from backend.open_webui.models.users import Users, UserResponse
+from open_webui.internal.db import Base, get_db
+from open_webui.models.groups import Groups
+from open_webui.utils.access_control import has_access
+from open_webui.models.users import Users, UserResponse
 
 
 from pydantic import BaseModel, ConfigDict

--- a/backend/open_webui/models/oauth_sessions.py
+++ b/backend/open_webui/models/oauth_sessions.py
@@ -8,8 +8,8 @@ import json
 
 from cryptography.fernet import Fernet
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.env import SRC_LOG_LEVELS, OAUTH_SESSION_TOKEN_ENCRYPTION_KEY
+from open_webui.internal.db import Base, get_db
+from open_webui.env import SRC_LOG_LEVELS, OAUTH_SESSION_TOKEN_ENCRYPTION_KEY
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, Text, Index

--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -1,14 +1,14 @@
 import time
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, get_db
-from backend.open_webui.models.groups import Groups
-from backend.open_webui.models.users import Users, UserResponse
+from open_webui.internal.db import Base, get_db
+from open_webui.models.groups import Groups
+from open_webui.models.users import Users, UserResponse
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, Text, JSON
 
-from backend.open_webui.utils.access_control import has_access
+from open_webui.utils.access_control import has_access
 
 ####################
 # Prompts DB Schema

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -3,10 +3,10 @@ import time
 import uuid
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, get_db
+from open_webui.internal.db import Base, get_db
 
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, JSON, PrimaryKeyConstraint, Index
 

--- a/backend/open_webui/models/tools.py
+++ b/backend/open_webui/models/tools.py
@@ -2,15 +2,15 @@ import logging
 import time
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, JSONField, get_db
-from backend.open_webui.models.users import Users, UserResponse
-from backend.open_webui.models.groups import Groups
+from open_webui.internal.db import Base, JSONField, get_db
+from open_webui.models.users import Users, UserResponse
+from open_webui.models.groups import Groups
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, Text, JSON
 
-from backend.open_webui.utils.access_control import has_access
+from open_webui.utils.access_control import has_access
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -1,13 +1,13 @@
 import time
 from typing import Optional
 
-from backend.open_webui.internal.db import Base, JSONField, get_db
+from open_webui.internal.db import Base, JSONField, get_db
 
 
-from backend.open_webui.env import DATABASE_USER_ACTIVE_STATUS_UPDATE_INTERVAL
-from backend.open_webui.models.chats import Chats
-from backend.open_webui.models.groups import Groups
-from backend.open_webui.utils.misc import throttle
+from open_webui.env import DATABASE_USER_ACTIVE_STATUS_UPDATE_INTERVAL
+from open_webui.models.chats import Chats
+from open_webui.models.groups import Groups
+from open_webui.utils.misc import throttle
 
 
 from pydantic import BaseModel, ConfigDict

--- a/backend/open_webui/retrieval/loaders/external_document.py
+++ b/backend/open_webui/retrieval/loaders/external_document.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 
 from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/loaders/external_web.py
+++ b/backend/open_webui/retrieval/loaders/external_web.py
@@ -4,7 +4,7 @@ from typing import Iterator, List, Union
 
 from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -23,13 +23,13 @@ from langchain_community.document_loaders import (
 )
 from langchain_core.documents import Document
 
-from backend.open_webui.retrieval.loaders.external_document import ExternalDocumentLoader
+from open_webui.retrieval.loaders.external_document import ExternalDocumentLoader
 
-from backend.open_webui.retrieval.loaders.mistral import MistralLoader
-from backend.open_webui.retrieval.loaders.datalab_marker import DatalabMarkerLoader
+from open_webui.retrieval.loaders.mistral import MistralLoader
+from open_webui.retrieval.loaders.datalab_marker import DatalabMarkerLoader
 
 
-from backend.open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
+from open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)

--- a/backend/open_webui/retrieval/loaders/mistral.py
+++ b/backend/open_webui/retrieval/loaders/mistral.py
@@ -9,7 +9,7 @@ from typing import List, Dict, Any
 from contextlib import asynccontextmanager
 
 from langchain_core.documents import Document
-from backend.open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
+from open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)

--- a/backend/open_webui/retrieval/loaders/tavily.py
+++ b/backend/open_webui/retrieval/loaders/tavily.py
@@ -4,7 +4,7 @@ from typing import Iterator, List, Literal, Union
 
 from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -4,7 +4,7 @@ from xml.etree.ElementTree import ParseError
 from typing import Any, Dict, Generator, List, Optional, Sequence, Union
 from urllib.parse import parse_qs, urlparse
 from langchain_core.documents import Document
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/models/colbert.py
+++ b/backend/open_webui/retrieval/models/colbert.py
@@ -5,9 +5,9 @@ import numpy as np
 from colbert.infra import ColBERTConfig
 from colbert.modeling.checkpoint import Checkpoint
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
-from backend.open_webui.retrieval.models.base_reranker import BaseReranker
+from open_webui.retrieval.models.base_reranker import BaseReranker
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/models/external.py
+++ b/backend/open_webui/retrieval/models/external.py
@@ -4,8 +4,8 @@ from typing import Optional, List, Tuple
 from urllib.parse import quote
 
 
-from backend.open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS, SRC_LOG_LEVELS
-from backend.open_webui.retrieval.models.base_reranker import BaseReranker
+from open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS, SRC_LOG_LEVELS
+from open_webui.retrieval.models.base_reranker import BaseReranker
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -13,27 +13,27 @@ from langchain.retrievers import ContextualCompressionRetriever, EnsembleRetriev
 from langchain_community.retrievers import BM25Retriever
 from langchain_core.documents import Document
 
-from backend.open_webui.config import VECTOR_DB
-from backend.open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
+from open_webui.config import VECTOR_DB
+from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 
-from backend.open_webui.models.users import UserModel
-from backend.open_webui.models.files import Files
-from backend.open_webui.models.knowledge import Knowledges
+from open_webui.models.users import UserModel
+from open_webui.models.files import Files
+from open_webui.models.knowledge import Knowledges
 
-from backend.open_webui.models.chats import Chats
-from backend.open_webui.models.notes import Notes
+from open_webui.models.chats import Chats
+from open_webui.models.notes import Notes
 
-from backend.open_webui.retrieval.vector.main import GetResult
-from backend.open_webui.utils.access_control import has_access
-from backend.open_webui.utils.misc import get_message_list
+from open_webui.retrieval.vector.main import GetResult
+from open_webui.utils.access_control import has_access
+from open_webui.utils.misc import get_message_list
 
 
-from backend.open_webui.env import (
+from open_webui.env import (
     SRC_LOG_LEVELS,
     OFFLINE_MODE,
     ENABLE_FORWARD_USER_INFO_HEADERS,
 )
-from backend.open_webui.config import (
+from open_webui.config import (
     RAG_EMBEDDING_QUERY_PREFIX,
     RAG_EMBEDDING_CONTENT_PREFIX,
     RAG_EMBEDDING_PREFIX_FIELD_NAME,

--- a/backend/open_webui/retrieval/vector/dbs/chroma.py
+++ b/backend/open_webui/retrieval/vector/dbs/chroma.py
@@ -5,15 +5,15 @@ from chromadb.utils.batch_utils import create_batches
 
 from typing import Optional
 
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     SearchResult,
     GetResult,
 )
-from backend.open_webui.retrieval.vector.utils import stringify_metadata
+from open_webui.retrieval.vector.utils import stringify_metadata
 
-from backend.open_webui.config import (
+from open_webui.config import (
     CHROMA_DATA_PATH,
     CHROMA_HTTP_HOST,
     CHROMA_HTTP_PORT,
@@ -24,7 +24,7 @@ from backend.open_webui.config import (
     CHROMA_CLIENT_AUTH_PROVIDER,
     CHROMA_CLIENT_AUTH_CREDENTIALS,
 )
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
@@ -3,14 +3,14 @@ from typing import Optional
 import ssl
 from elasticsearch.helpers import bulk, scan
 
-from backend.open_webui.retrieval.vector.utils import stringify_metadata
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.utils import stringify_metadata
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     SearchResult,
     GetResult,
 )
-from backend.open_webui.config import (
+from open_webui.config import (
     ELASTICSEARCH_URL,
     ELASTICSEARCH_CA_CERTS,
     ELASTICSEARCH_API_KEY,

--- a/backend/open_webui/retrieval/vector/dbs/milvus.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus.py
@@ -6,14 +6,14 @@ import json
 import logging
 from typing import Optional
 
-from backend.open_webui.retrieval.vector.utils import stringify_metadata
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.utils import stringify_metadata
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     SearchResult,
     GetResult,
 )
-from backend.open_webui.config import (
+from open_webui.config import (
     MILVUS_URI,
     MILVUS_DB,
     MILVUS_TOKEN,
@@ -23,7 +23,7 @@ from backend.open_webui.config import (
     MILVUS_HNSW_EFCONSTRUCTION,
     MILVUS_IVF_FLAT_NLIST,
 )
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -2,14 +2,14 @@ from opensearchpy import OpenSearch
 from opensearchpy.helpers import bulk
 from typing import Optional
 
-from backend.open_webui.retrieval.vector.utils import stringify_metadata
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.utils import stringify_metadata
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     SearchResult,
     GetResult,
 )
-from backend.open_webui.config import (
+from open_webui.config import (
     OPENSEARCH_URI,
     OPENSEARCH_SSL,
     OPENSEARCH_CERT_VERIFY,

--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -36,14 +36,14 @@ import json
 import array
 import oracledb
 
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     SearchResult,
     GetResult,
 )
 
-from backend.open_webui.config import (
+from open_webui.config import (
     ORACLE_DB_USE_WALLET,
     ORACLE_DB_USER,
     ORACLE_DB_PASSWORD,
@@ -55,7 +55,7 @@ from backend.open_webui.config import (
     ORACLE_DB_POOL_MAX,
     ORACLE_DB_POOL_INCREMENT,
 )
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/vector/dbs/pgvector.py
+++ b/backend/open_webui/retrieval/vector/dbs/pgvector.py
@@ -27,14 +27,14 @@ from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.exc import NoSuchTableError
 
 
-from backend.open_webui.retrieval.vector.utils import stringify_metadata
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.utils import stringify_metadata
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     SearchResult,
     GetResult,
 )
-from backend.open_webui.config import (
+from open_webui.config import (
     PGVECTOR_DB_URL,
     PGVECTOR_INITIALIZE_MAX_VECTOR_LENGTH,
     PGVECTOR_CREATE_EXTENSION,
@@ -46,7 +46,7 @@ from backend.open_webui.config import (
     PGVECTOR_POOL_RECYCLE,
 )
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 VECTOR_LENGTH = PGVECTOR_INITIALIZE_MAX_VECTOR_LENGTH
 Base = declarative_base()

--- a/backend/open_webui/retrieval/vector/dbs/pinecone.py
+++ b/backend/open_webui/retrieval/vector/dbs/pinecone.py
@@ -17,13 +17,13 @@ import functools  # for partial binding in async tasks
 import concurrent.futures  # for parallel batch upserts
 import random  # for jitter in retry backoff
 
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     SearchResult,
     GetResult,
 )
-from backend.open_webui.config import (
+from open_webui.config import (
     PINECONE_API_KEY,
     PINECONE_ENVIRONMENT,
     PINECONE_INDEX_NAME,
@@ -31,8 +31,8 @@ from backend.open_webui.config import (
     PINECONE_METRIC,
     PINECONE_CLOUD,
 )
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.retrieval.vector.utils import stringify_metadata
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.vector.utils import stringify_metadata
 
 
 NO_LIMIT = 10000  # Reasonable limit to avoid overwhelming the system

--- a/backend/open_webui/retrieval/vector/dbs/qdrant.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant.py
@@ -6,13 +6,13 @@ from qdrant_client import QdrantClient as Qclient
 from qdrant_client.http.models import PointStruct
 from qdrant_client.models import models
 
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     SearchResult,
     GetResult,
 )
-from backend.open_webui.config import (
+from open_webui.config import (
     QDRANT_URI,
     QDRANT_API_KEY,
     QDRANT_ON_DISK,
@@ -22,7 +22,7 @@ from backend.open_webui.config import (
     QDRANT_TIMEOUT,
     QDRANT_HNSW_M,
 )
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 NO_LIMIT = 999999999
 

--- a/backend/open_webui/retrieval/vector/dbs/qdrant_multitenancy.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant_multitenancy.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, List, Dict, Any
 from urllib.parse import urlparse
 
 import grpc
-from backend.open_webui.config import (
+from open_webui.config import (
     QDRANT_API_KEY,
     QDRANT_GRPC_PORT,
     QDRANT_ON_DISK,
@@ -13,8 +13,8 @@ from backend.open_webui.config import (
     QDRANT_TIMEOUT,
     QDRANT_HNSW_M,
 )
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.vector.main import (
     GetResult,
     SearchResult,
     VectorDBBase,

--- a/backend/open_webui/retrieval/vector/dbs/s3vector.py
+++ b/backend/open_webui/retrieval/vector/dbs/s3vector.py
@@ -1,12 +1,12 @@
-from backend.open_webui.retrieval.vector.utils import stringify_metadata
-from backend.open_webui.retrieval.vector.main import (
+from open_webui.retrieval.vector.utils import stringify_metadata
+from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
     GetResult,
     SearchResult,
 )
-from backend.open_webui.config import S3_VECTOR_BUCKET_NAME, S3_VECTOR_REGION
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import S3_VECTOR_BUCKET_NAME, S3_VECTOR_REGION
+from open_webui.env import SRC_LOG_LEVELS
 from typing import List, Optional, Dict, Any, Union
 import logging
 import boto3

--- a/backend/open_webui/retrieval/vector/factory.py
+++ b/backend/open_webui/retrieval/vector/factory.py
@@ -1,6 +1,6 @@
-from backend.open_webui.retrieval.vector.main import VectorDBBase
-from backend.open_webui.retrieval.vector.type import VectorType
-from backend.open_webui.config import VECTOR_DB, ENABLE_QDRANT_MULTITENANCY_MODE
+from open_webui.retrieval.vector.main import VectorDBBase
+from open_webui.retrieval.vector.type import VectorType
+from open_webui.config import VECTOR_DB, ENABLE_QDRANT_MULTITENANCY_MODE
 
 
 class Vector:

--- a/backend/open_webui/retrieval/web/bing.py
+++ b/backend/open_webui/retrieval/web/bing.py
@@ -3,8 +3,8 @@ import os
 from pprint import pprint
 from typing import Optional
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 import argparse
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/retrieval/web/bocha.py
+++ b/backend/open_webui/retrieval/web/bocha.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 import requests
 import json
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/brave.py
+++ b/backend/open_webui/retrieval/web/brave.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Optional
 
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from ddgs import DDGS
 from ddgs.exceptions import RatelimitException
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/exa.py
+++ b/backend/open_webui/retrieval/web/exa.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 import requests
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.retrieval.web.main import SearchResult
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/external.py
+++ b/backend/open_webui/retrieval/web/external.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional, List
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/firecrawl.py
+++ b/backend/open_webui/retrieval/web/firecrawl.py
@@ -3,8 +3,8 @@ from typing import Optional, List
 from urllib.parse import urljoin
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/google_pse.py
+++ b/backend/open_webui/retrieval/web/google_pse.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/jina_search.py
+++ b/backend/open_webui/retrieval/web/jina_search.py
@@ -1,8 +1,8 @@
 import logging
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult
+from open_webui.env import SRC_LOG_LEVELS
 from yarl import URL
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/retrieval/web/kagi.py
+++ b/backend/open_webui/retrieval/web/kagi.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/mojeek.py
+++ b/backend/open_webui/retrieval/web/mojeek.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/ollama.py
+++ b/backend/open_webui/retrieval/web/ollama.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 import requests
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.retrieval.web.main import SearchResult
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/perplexity.py
+++ b/backend/open_webui/retrieval/web/perplexity.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional, Literal
 import requests
 
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 MODELS = Literal[
     "sonar",

--- a/backend/open_webui/retrieval/web/perplexity_search.py
+++ b/backend/open_webui/retrieval/web/perplexity_search.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional, Literal
 import requests
 
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/retrieval/web/searchapi.py
+++ b/backend/open_webui/retrieval/web/searchapi.py
@@ -3,8 +3,8 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/searxng.py
+++ b/backend/open_webui/retrieval/web/searxng.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/serpapi.py
+++ b/backend/open_webui/retrieval/web/serpapi.py
@@ -3,8 +3,8 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/serper.py
+++ b/backend/open_webui/retrieval/web/serper.py
@@ -3,8 +3,8 @@ import logging
 from typing import Optional
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/serply.py
+++ b/backend/open_webui/retrieval/web/serply.py
@@ -3,8 +3,8 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/serpstack.py
+++ b/backend/open_webui/retrieval/web/serpstack.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/sougou.py
+++ b/backend/open_webui/retrieval/web/sougou.py
@@ -3,8 +3,8 @@ import json
 from typing import Optional, List
 
 
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/tavily.py
+++ b/backend/open_webui/retrieval/web/tavily.py
@@ -2,8 +2,8 @@ import logging
 from typing import Optional
 
 import requests
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -24,10 +24,10 @@ from langchain_community.document_loaders import PlaywrightURLLoader, WebBaseLoa
 from langchain_community.document_loaders.firecrawl import FireCrawlLoader
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
-from backend.open_webui.retrieval.loaders.tavily import TavilyLoader
-from backend.open_webui.retrieval.loaders.external_web import ExternalWebLoader
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.config import (
+from open_webui.retrieval.loaders.tavily import TavilyLoader
+from open_webui.retrieval.loaders.external_web import ExternalWebLoader
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.config import (
     ENABLE_RAG_LOCAL_WEB_FETCH,
     PLAYWRIGHT_WS_URL,
     PLAYWRIGHT_TIMEOUT,
@@ -39,7 +39,7 @@ from backend.open_webui.config import (
     EXTERNAL_WEB_LOADER_URL,
     EXTERNAL_WEB_LOADER_API_KEY,
 )
-from backend.open_webui.env import SRC_LOG_LEVELS, AIOHTTP_CLIENT_SESSION_SSL
+from open_webui.env import SRC_LOG_LEVELS, AIOHTTP_CLIENT_SESSION_SSL
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/retrieval/web/yacy.py
+++ b/backend/open_webui/retrieval/web/yacy.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 import requests
 from requests.auth import HTTPDigestAuth
-from backend.open_webui.retrieval.web.main import SearchResult, get_filtered_results
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -32,16 +32,16 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.config import (
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.config import (
     WHISPER_MODEL_AUTO_UPDATE,
     WHISPER_MODEL_DIR,
     CACHE_DIR,
     WHISPER_LANGUAGE,
 )
 
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import (
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     AIOHTTP_CLIENT_TIMEOUT,
     ENV,

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 from aiohttp import ClientSession
 
-from backend.open_webui.models.auths import (
+from open_webui.models.auths import (
     AddUserForm,
     ApiKey,
     Auths,
@@ -17,12 +17,12 @@ from backend.open_webui.models.auths import (
     UpdatePasswordForm,
     UserResponse,
 )
-from backend.open_webui.models.users import Users, UpdateProfileForm
-from backend.open_webui.models.groups import Groups
-from backend.open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.users import Users, UpdateProfileForm
+from open_webui.models.groups import Groups
+from open_webui.models.oauth_sessions import OAuthSessions
 
-from backend.open_webui.constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
-from backend.open_webui.env import (
+from open_webui.constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
+from open_webui.env import (
     WEBUI_AUTH,
     WEBUI_AUTH_TRUSTED_EMAIL_HEADER,
     WEBUI_AUTH_TRUSTED_NAME_HEADER,
@@ -35,11 +35,11 @@ from backend.open_webui.env import (
 )
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response, JSONResponse
-from backend.open_webui.config import OPENID_PROVIDER_URL, ENABLE_OAUTH_SIGNUP, ENABLE_LDAP
+from open_webui.config import OPENID_PROVIDER_URL, ENABLE_OAUTH_SIGNUP, ENABLE_LDAP
 from pydantic import BaseModel
 
-from backend.open_webui.utils.misc import parse_duration, validate_email_format
-from backend.open_webui.utils.auth import (
+from open_webui.utils.misc import parse_duration, validate_email_format
+from open_webui.utils.auth import (
     decode_token,
     create_api_key,
     create_token,
@@ -49,8 +49,8 @@ from backend.open_webui.utils.auth import (
     get_password_hash,
     get_http_authorization_cred,
 )
-from backend.open_webui.utils.webhook import post_webhook
-from backend.open_webui.utils.access_control import get_permissions
+from open_webui.utils.webhook import post_webhook
+from open_webui.utils.access_control import get_permissions
 
 from typing import Optional, List
 

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -7,17 +7,17 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status, Backgrou
 from pydantic import BaseModel
 
 
-from backend.open_webui.socket.main import sio, get_user_ids_from_room
-from backend.open_webui.models.users import Users, UserNameResponse
+from open_webui.socket.main import sio, get_user_ids_from_room
+from open_webui.models.users import Users, UserNameResponse
 
-from backend.open_webui.models.groups import Groups
-from backend.open_webui.models.channels import (
+from open_webui.models.groups import Groups
+from open_webui.models.channels import (
     Channels,
     ChannelModel,
     ChannelForm,
     ChannelResponse,
 )
-from backend.open_webui.models.messages import (
+from open_webui.models.messages import (
     Messages,
     MessageModel,
     MessageResponse,
@@ -25,22 +25,22 @@ from backend.open_webui.models.messages import (
 )
 
 
-from backend.open_webui.config import ENABLE_ADMIN_CHAT_ACCESS, ENABLE_ADMIN_EXPORT
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import ENABLE_ADMIN_CHAT_ACCESS, ENABLE_ADMIN_EXPORT
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS
 
 
-from backend.open_webui.utils.models import (
+from open_webui.utils.models import (
     get_all_models,
     get_filtered_models,
 )
-from backend.open_webui.utils.chat import generate_chat_completion
+from open_webui.utils.chat import generate_chat_completion
 
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_access, get_users_with_access
-from backend.open_webui.utils.webhook import post_webhook
-from backend.open_webui.utils.channels import extract_mentions, replace_mentions
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_access, get_users_with_access
+from open_webui.utils.webhook import post_webhook
+from open_webui.utils.channels import extract_mentions, replace_mentions
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -3,26 +3,26 @@ import logging
 from typing import Optional
 
 
-from backend.open_webui.socket.main import get_event_emitter
-from backend.open_webui.models.chats import (
+from open_webui.socket.main import get_event_emitter
+from open_webui.models.chats import (
     ChatForm,
     ChatImportForm,
     ChatResponse,
     Chats,
     ChatTitleIdResponse,
 )
-from backend.open_webui.models.tags import TagModel, Tags
-from backend.open_webui.models.folders import Folders
+from open_webui.models.tags import TagModel, Tags
+from open_webui.models.folders import Folders
 
-from backend.open_webui.config import ENABLE_ADMIN_CHAT_ACCESS, ENABLE_ADMIN_EXPORT
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import ENABLE_ADMIN_CHAT_ACCESS, ENABLE_ADMIN_EXPORT
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_permission
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_permission
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -5,20 +5,20 @@ import aiohttp
 
 from typing import Optional
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.config import get_config, save_config
-from backend.open_webui.config import BannerModel
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.config import get_config, save_config
+from open_webui.config import BannerModel
 
-from backend.open_webui.utils.tools import (
+from open_webui.utils.tools import (
     get_tool_server_data,
     get_tool_server_url,
     set_tool_servers,
 )
-from backend.open_webui.utils.mcp.client import MCPClient
+from open_webui.utils.mcp.client import MCPClient
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
-from backend.open_webui.utils.oauth import (
+from open_webui.utils.oauth import (
     get_discovery_urls,
     get_oauth_client_info_with_dynamic_client_registration,
     encrypt_data,

--- a/backend/open_webui/routers/evaluations.py
+++ b/backend/open_webui/routers/evaluations.py
@@ -2,16 +2,16 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from pydantic import BaseModel
 
-from backend.open_webui.models.users import Users, UserModel
-from backend.open_webui.models.feedbacks import (
+from open_webui.models.users import Users, UserModel
+from open_webui.models.feedbacks import (
     FeedbackModel,
     FeedbackResponse,
     FeedbackForm,
     Feedbacks,
 )
 
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.utils.auth import get_admin_user, get_verified_user
 
 router = APIRouter()
 

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -22,24 +22,24 @@ from fastapi import (
 )
 
 from fastapi.responses import FileResponse, StreamingResponse
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 
-from backend.open_webui.models.users import Users
-from backend.open_webui.models.files import (
+from open_webui.models.users import Users
+from open_webui.models.files import (
     FileForm,
     FileModel,
     FileModelResponse,
     Files,
 )
-from backend.open_webui.models.knowledge import Knowledges
+from open_webui.models.knowledge import Knowledges
 
-from backend.open_webui.routers.knowledge import get_knowledge, get_knowledge_list
-from backend.open_webui.routers.retrieval import ProcessFileForm, process_file
-from backend.open_webui.routers.audio import transcribe
-from backend.open_webui.storage.provider import Storage
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.routers.knowledge import get_knowledge, get_knowledge_list
+from open_webui.routers.retrieval import ProcessFileForm, process_file
+from open_webui.routers.audio import transcribe
+from open_webui.storage.provider import Storage
+from open_webui.utils.auth import get_admin_user, get_verified_user
 from pydantic import BaseModel
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -8,28 +8,28 @@ from pydantic import BaseModel
 import mimetypes
 
 
-from backend.open_webui.models.folders import (
+from open_webui.models.folders import (
     FolderForm,
     FolderUpdateForm,
     FolderModel,
     Folders,
 )
-from backend.open_webui.models.chats import Chats
-from backend.open_webui.models.files import Files
-from backend.open_webui.models.knowledge import Knowledges
+from open_webui.models.chats import Chats
+from open_webui.models.files import Files
+from open_webui.models.knowledge import Knowledges
 
 
-from backend.open_webui.config import UPLOAD_DIR
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.config import UPLOAD_DIR
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.constants import ERROR_MESSAGES
 
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status, Request
 from fastapi.responses import FileResponse, StreamingResponse
 
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_permission
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_permission
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/functions.py
+++ b/backend/open_webui/routers/functions.py
@@ -6,23 +6,23 @@ import aiohttp
 from pathlib import Path
 from typing import Optional
 
-from backend.open_webui.models.functions import (
+from open_webui.models.functions import (
     FunctionForm,
     FunctionModel,
     FunctionResponse,
     FunctionWithValvesModel,
     Functions,
 )
-from backend.open_webui.utils.plugin import (
+from open_webui.utils.plugin import (
     load_function_module_by_id,
     replace_imports,
     get_function_module_from_cache,
 )
-from backend.open_webui.config import CACHE_DIR
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.config import CACHE_DIR
+from open_webui.constants import ERROR_MESSAGES
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel, HttpUrl
 
 

--- a/backend/open_webui/routers/groups.py
+++ b/backend/open_webui/routers/groups.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import Optional
 import logging
 
-from backend.open_webui.models.users import Users
-from backend.open_webui.models.groups import (
+from open_webui.models.users import Users
+from open_webui.models.groups import (
     Groups,
     GroupForm,
     GroupUpdateForm,
@@ -12,12 +12,12 @@ from backend.open_webui.models.groups import (
     UserIdsForm,
 )
 
-from backend.open_webui.config import CACHE_DIR
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.config import CACHE_DIR
+from open_webui.constants import ERROR_MESSAGES
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.env import SRC_LOG_LEVELS
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -18,12 +18,12 @@ from fastapi import (
     UploadFile,
 )
 
-from backend.open_webui.config import CACHE_DIR
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS, SRC_LOG_LEVELS
-from backend.open_webui.routers.files import upload_file_handler
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.images.comfyui import (
+from open_webui.config import CACHE_DIR
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS, SRC_LOG_LEVELS
+from open_webui.routers.files import upload_file_handler
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.images.comfyui import (
     ComfyUIGenerateImageForm,
     ComfyUIWorkflow,
     comfyui_generate_image,

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -3,30 +3,30 @@ from pydantic import BaseModel
 from fastapi import APIRouter, Depends, HTTPException, status, Request, Query
 import logging
 
-from backend.open_webui.models.knowledge import (
+from open_webui.models.knowledge import (
     Knowledges,
     KnowledgeForm,
     KnowledgeResponse,
     KnowledgeUserResponse,
 )
-from backend.open_webui.models.files import Files, FileModel, FileMetadataResponse
-from backend.open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
-from backend.open_webui.routers.retrieval import (
+from open_webui.models.files import Files, FileModel, FileMetadataResponse
+from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
+from open_webui.routers.retrieval import (
     process_file,
     ProcessFileForm,
     process_files_batch,
     BatchProcessFilesForm,
 )
-from backend.open_webui.storage.provider import Storage
+from open_webui.storage.provider import Storage
 
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.utils.auth import get_verified_user
-from backend.open_webui.utils.access_control import has_access, has_permission
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.utils.auth import get_verified_user
+from open_webui.utils.access_control import has_access, has_permission
 
 
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL
-from backend.open_webui.models.models import Models, ModelForm
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL
+from open_webui.models.models import Models, ModelForm
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/memories.py
+++ b/backend/open_webui/routers/memories.py
@@ -3,10 +3,10 @@ from pydantic import BaseModel
 import logging
 from typing import Optional
 
-from backend.open_webui.models.memories import Memories, MemoryModel
-from backend.open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
-from backend.open_webui.utils.auth import get_verified_user
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.models.memories import Memories, MemoryModel
+from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
+from open_webui.utils.auth import get_verified_user
+from open_webui.env import SRC_LOG_LEVELS
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -2,7 +2,7 @@ from typing import Optional
 import io
 import base64
 
-from backend.open_webui.models.models import (
+from open_webui.models.models import (
     ModelForm,
     ModelModel,
     ModelResponse,
@@ -11,14 +11,14 @@ from backend.open_webui.models.models import (
 )
 
 from pydantic import BaseModel
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.constants import ERROR_MESSAGES
 from fastapi import APIRouter, Depends, HTTPException, Request, status, Response
 from fastapi.responses import FileResponse, StreamingResponse
 
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_access, has_permission
-from backend.open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL, STATIC_DIR
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_access, has_permission
+from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL, STATIC_DIR
 
 router = APIRouter()
 

--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -6,19 +6,19 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, status, BackgroundTasks
 from pydantic import BaseModel
 
-from backend.open_webui.socket.main import sio
+from open_webui.socket.main import sio
 
 
-from backend.open_webui.models.users import Users, UserResponse
-from backend.open_webui.models.notes import Notes, NoteModel, NoteForm, NoteUserResponse
+from open_webui.models.users import Users, UserResponse
+from open_webui.models.notes import Notes, NoteModel, NoteForm, NoteUserResponse
 
-from backend.open_webui.config import ENABLE_ADMIN_CHAT_ACCESS, ENABLE_ADMIN_EXPORT
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import ENABLE_ADMIN_CHAT_ACCESS, ENABLE_ADMIN_EXPORT
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS
 
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_access, has_permission
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_access, has_permission
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -18,10 +18,10 @@ from aiocache import cached
 import requests
 from urllib.parse import quote
 
-from backend.open_webui.models.chats import Chats
-from backend.open_webui.models.users import UserModel
+from open_webui.models.chats import Chats
+from open_webui.models.users import UserModel
 
-from backend.open_webui.env import (
+from open_webui.env import (
     ENABLE_FORWARD_USER_INFO_HEADERS,
 )
 
@@ -40,23 +40,23 @@ from pydantic import BaseModel, ConfigDict, validator
 from starlette.background import BackgroundTask
 
 
-from backend.open_webui.models.models import Models
-from backend.open_webui.utils.misc import (
+from open_webui.models.models import Models
+from open_webui.utils.misc import (
     calculate_sha256,
 )
-from backend.open_webui.utils.payload import (
+from open_webui.utils.payload import (
     apply_model_params_to_body_ollama,
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
 )
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_access
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_access
 
 
-from backend.open_webui.config import (
+from open_webui.config import (
     UPLOAD_DIR,
 )
-from backend.open_webui.env import (
+from open_webui.env import (
     ENV,
     SRC_LOG_LEVELS,
     MODELS_CACHE_TTL,
@@ -65,7 +65,7 @@ from backend.open_webui.env import (
     AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST,
     BYPASS_MODEL_ACCESS_CONTROL,
 )
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.constants import ERROR_MESSAGES
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["OLLAMA"])

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -21,11 +21,11 @@ from fastapi.responses import (
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 
-from backend.open_webui.models.models import Models
-from backend.open_webui.config import (
+from open_webui.models.models import Models
+from open_webui.config import (
     CACHE_DIR,
 )
-from backend.open_webui.env import (
+from open_webui.env import (
     MODELS_CACHE_TTL,
     AIOHTTP_CLIENT_SESSION_SSL,
     AIOHTTP_CLIENT_TIMEOUT,
@@ -33,22 +33,22 @@ from backend.open_webui.env import (
     ENABLE_FORWARD_USER_INFO_HEADERS,
     BYPASS_MODEL_ACCESS_CONTROL,
 )
-from backend.open_webui.models.users import UserModel
+from open_webui.models.users import UserModel
 
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS
 
 
-from backend.open_webui.utils.payload import (
+from open_webui.utils.payload import (
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
 )
-from backend.open_webui.utils.misc import (
+from open_webui.utils.misc import (
     convert_logit_bias_input_to_json,
 )
 
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_access
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_access
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -18,14 +18,14 @@ from pydantic import BaseModel
 from starlette.responses import FileResponse
 from typing import Optional
 
-from backend.open_webui.env import SRC_LOG_LEVELS, AIOHTTP_CLIENT_SESSION_SSL
-from backend.open_webui.config import CACHE_DIR
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS, AIOHTTP_CLIENT_SESSION_SSL
+from open_webui.config import CACHE_DIR
+from open_webui.constants import ERROR_MESSAGES
 
 
-from backend.open_webui.routers.openai import get_all_models_responses
+from open_webui.routers.openai import get_all_models_responses
 
-from backend.open_webui.utils.auth import get_admin_user
+from open_webui.utils.auth import get_admin_user
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MAIN"])

--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -1,16 +1,16 @@
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 
-from backend.open_webui.models.prompts import (
+from open_webui.models.prompts import (
     PromptForm,
     PromptUserResponse,
     PromptModel,
     Prompts,
 )
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_access, has_permission
-from backend.open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_access, has_permission
+from open_webui.config import BYPASS_ADMIN_ACCESS_CONTROL
 
 router = APIRouter()
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -31,45 +31,45 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter, TokenTextSpl
 from langchain_text_splitters import MarkdownHeaderTextSplitter
 from langchain_core.documents import Document
 
-from backend.open_webui.models.files import FileModel, Files
-from backend.open_webui.models.knowledge import Knowledges
-from backend.open_webui.storage.provider import Storage
+from open_webui.models.files import FileModel, Files
+from open_webui.models.knowledge import Knowledges
+from open_webui.storage.provider import Storage
 
 
-from backend.open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
+from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 
 # Document loaders
-from backend.open_webui.retrieval.loaders.main import Loader
-from backend.open_webui.retrieval.loaders.youtube import YoutubeLoader
+from open_webui.retrieval.loaders.main import Loader
+from open_webui.retrieval.loaders.youtube import YoutubeLoader
 
 # Web search engines
-from backend.open_webui.retrieval.web.main import SearchResult
-from backend.open_webui.retrieval.web.utils import get_web_loader
-from backend.open_webui.retrieval.web.ollama import search_ollama_cloud
-from backend.open_webui.retrieval.web.perplexity_search import search_perplexity_search
-from backend.open_webui.retrieval.web.brave import search_brave
-from backend.open_webui.retrieval.web.kagi import search_kagi
-from backend.open_webui.retrieval.web.mojeek import search_mojeek
-from backend.open_webui.retrieval.web.bocha import search_bocha
-from backend.open_webui.retrieval.web.duckduckgo import search_duckduckgo
-from backend.open_webui.retrieval.web.google_pse import search_google_pse
-from backend.open_webui.retrieval.web.jina_search import search_jina
-from backend.open_webui.retrieval.web.searchapi import search_searchapi
-from backend.open_webui.retrieval.web.serpapi import search_serpapi
-from backend.open_webui.retrieval.web.searxng import search_searxng
-from backend.open_webui.retrieval.web.yacy import search_yacy
-from backend.open_webui.retrieval.web.serper import search_serper
-from backend.open_webui.retrieval.web.serply import search_serply
-from backend.open_webui.retrieval.web.serpstack import search_serpstack
-from backend.open_webui.retrieval.web.tavily import search_tavily
-from backend.open_webui.retrieval.web.bing import search_bing
-from backend.open_webui.retrieval.web.exa import search_exa
-from backend.open_webui.retrieval.web.perplexity import search_perplexity
-from backend.open_webui.retrieval.web.sougou import search_sougou
-from backend.open_webui.retrieval.web.firecrawl import search_firecrawl
-from backend.open_webui.retrieval.web.external import search_external
+from open_webui.retrieval.web.main import SearchResult
+from open_webui.retrieval.web.utils import get_web_loader
+from open_webui.retrieval.web.ollama import search_ollama_cloud
+from open_webui.retrieval.web.perplexity_search import search_perplexity_search
+from open_webui.retrieval.web.brave import search_brave
+from open_webui.retrieval.web.kagi import search_kagi
+from open_webui.retrieval.web.mojeek import search_mojeek
+from open_webui.retrieval.web.bocha import search_bocha
+from open_webui.retrieval.web.duckduckgo import search_duckduckgo
+from open_webui.retrieval.web.google_pse import search_google_pse
+from open_webui.retrieval.web.jina_search import search_jina
+from open_webui.retrieval.web.searchapi import search_searchapi
+from open_webui.retrieval.web.serpapi import search_serpapi
+from open_webui.retrieval.web.searxng import search_searxng
+from open_webui.retrieval.web.yacy import search_yacy
+from open_webui.retrieval.web.serper import search_serper
+from open_webui.retrieval.web.serply import search_serply
+from open_webui.retrieval.web.serpstack import search_serpstack
+from open_webui.retrieval.web.tavily import search_tavily
+from open_webui.retrieval.web.bing import search_bing
+from open_webui.retrieval.web.exa import search_exa
+from open_webui.retrieval.web.perplexity import search_perplexity
+from open_webui.retrieval.web.sougou import search_sougou
+from open_webui.retrieval.web.firecrawl import search_firecrawl
+from open_webui.retrieval.web.external import search_external
 
-from backend.open_webui.retrieval.utils import (
+from open_webui.retrieval.utils import (
     get_embedding_function,
     get_reranking_function,
     get_model_path,
@@ -78,12 +78,12 @@ from backend.open_webui.retrieval.utils import (
     query_doc,
     query_doc_with_hybrid_search,
 )
-from backend.open_webui.utils.misc import (
+from open_webui.utils.misc import (
     calculate_sha256_string,
 )
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.auth import get_admin_user, get_verified_user
 
-from backend.open_webui.config import (
+from open_webui.config import (
     ENV,
     RAG_EMBEDDING_MODEL_AUTO_UPDATE,
     RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE,
@@ -94,7 +94,7 @@ from backend.open_webui.config import (
     RAG_EMBEDDING_CONTENT_PREFIX,
     RAG_EMBEDDING_QUERY_PREFIX,
 )
-from backend.open_webui.env import (
+from open_webui.env import (
     SRC_LOG_LEVELS,
     DEVICE_TYPE,
     DOCKER,
@@ -104,7 +104,7 @@ from backend.open_webui.env import (
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
 )
 
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.constants import ERROR_MESSAGES
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["RAG"])

--- a/backend/open_webui/routers/scim.py
+++ b/backend/open_webui/routers/scim.py
@@ -15,16 +15,16 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Query, Header, s
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, ConfigDict
 
-from backend.open_webui.models.users import Users, UserModel
-from backend.open_webui.models.groups import Groups, GroupModel
-from backend.open_webui.utils.auth import (
+from open_webui.models.users import Users, UserModel
+from open_webui.models.groups import Groups, GroupModel
+from open_webui.utils.auth import (
     get_admin_user,
     get_current_user,
     decode_token,
     get_verified_user,
 )
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MAIN"])

--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -6,8 +6,8 @@ from typing import Optional
 import logging
 import re
 
-from backend.open_webui.utils.chat import generate_chat_completion
-from backend.open_webui.utils.task import (
+from open_webui.utils.chat import generate_chat_completion
+from open_webui.utils.task import (
     title_generation_template,
     follow_up_generation_template,
     query_generation_template,
@@ -17,14 +17,14 @@ from backend.open_webui.utils.task import (
     emoji_generation_template,
     moa_response_generation_template,
 )
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.constants import TASKS
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.constants import TASKS
 
-from backend.open_webui.routers.pipelines import process_pipeline_inlet_filter
+from open_webui.routers.pipelines import process_pipeline_inlet_filter
 
-from backend.open_webui.utils.task import get_task_model_id
+from open_webui.utils.task import get_task_model_id
 
-from backend.open_webui.config import (
+from open_webui.config import (
     DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE,
     DEFAULT_FOLLOW_UP_GENERATION_PROMPT_TEMPLATE,
     DEFAULT_TAGS_GENERATION_PROMPT_TEMPLATE,
@@ -34,7 +34,7 @@ from backend.open_webui.config import (
     DEFAULT_EMOJI_GENERATION_PROMPT_TEMPLATE,
     DEFAULT_MOA_GENERATION_PROMPT_TEMPLATE,
 )
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -4,28 +4,28 @@ from typing import Optional
 import time
 import re
 import aiohttp
-from backend.open_webui.models.groups import Groups
+from open_webui.models.groups import Groups
 from pydantic import BaseModel, HttpUrl
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 
-from backend.open_webui.models.oauth_sessions import OAuthSessions
-from backend.open_webui.models.tools import (
+from open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.tools import (
     ToolForm,
     ToolModel,
     ToolResponse,
     ToolUserResponse,
     Tools,
 )
-from backend.open_webui.utils.plugin import load_tool_module_by_id, replace_imports
-from backend.open_webui.utils.tools import get_tool_specs
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.access_control import has_access, has_permission
-from backend.open_webui.utils.tools import get_tool_servers
+from open_webui.utils.plugin import load_tool_module_by_id, replace_imports
+from open_webui.utils.tools import get_tool_specs
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_access, has_permission
+from open_webui.utils.tools import get_tool_servers
 
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.config import CACHE_DIR, BYPASS_ADMIN_ACCESS_CONTROL
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import CACHE_DIR, BYPASS_ADMIN_ACCESS_CONTROL
+from open_webui.constants import ERROR_MESSAGES
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -9,12 +9,12 @@ from fastapi.responses import Response, StreamingResponse, FileResponse
 from pydantic import BaseModel
 
 
-from backend.open_webui.models.auths import Auths
-from backend.open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.auths import Auths
+from open_webui.models.oauth_sessions import OAuthSessions
 
-from backend.open_webui.models.groups import Groups
-from backend.open_webui.models.chats import Chats
-from backend.open_webui.models.users import (
+from open_webui.models.groups import Groups
+from open_webui.models.chats import Chats
+from open_webui.models.users import (
     UserModel,
     UserListResponse,
     UserInfoListResponse,
@@ -26,17 +26,17 @@ from backend.open_webui.models.users import (
 )
 
 
-from backend.open_webui.socket.main import (
+from open_webui.socket.main import (
     get_active_status_by_user_id,
     get_active_user_ids,
     get_user_active_status,
 )
-from backend.open_webui.constants import ERROR_MESSAGES
-from backend.open_webui.env import SRC_LOG_LEVELS, STATIC_DIR
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.env import SRC_LOG_LEVELS, STATIC_DIR
 
 
-from backend.open_webui.utils.auth import get_admin_user, get_password_hash, get_verified_user
-from backend.open_webui.utils.access_control import get_permissions, has_permission
+from open_webui.utils.auth import get_admin_user, get_password_hash, get_verified_user
+from open_webui.utils.access_control import get_permissions, has_permission
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/routers/utils.py
+++ b/backend/open_webui/routers/utils.py
@@ -2,19 +2,19 @@ import black
 import logging
 import markdown
 
-from backend.open_webui.models.chats import ChatTitleMessagesForm
-from backend.open_webui.config import DATA_DIR, ENABLE_ADMIN_EXPORT
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.models.chats import ChatTitleMessagesForm
+from open_webui.config import DATA_DIR, ENABLE_ADMIN_EXPORT
+from open_webui.constants import ERROR_MESSAGES
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel
 from starlette.responses import FileResponse
 
 
-from backend.open_webui.utils.misc import get_gravatar_url
-from backend.open_webui.utils.pdf_generator import PDFGenerator
-from backend.open_webui.utils.auth import get_admin_user, get_verified_user
-from backend.open_webui.utils.code_interpreter import execute_code_jupyter
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.utils.misc import get_gravatar_url
+from open_webui.utils.pdf_generator import PDFGenerator
+from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.code_interpreter import execute_code_jupyter
+from open_webui.env import SRC_LOG_LEVELS
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -9,16 +9,16 @@ from typing import Dict, Set
 from redis import asyncio as aioredis
 import pycrdt as Y
 
-from backend.open_webui.models.users import Users, UserNameResponse
-from backend.open_webui.models.channels import Channels
-from backend.open_webui.models.chats import Chats
-from backend.open_webui.models.notes import Notes, NoteUpdateForm
-from backend.open_webui.utils.redis import (
+from open_webui.models.users import Users, UserNameResponse
+from open_webui.models.channels import Channels
+from open_webui.models.chats import Chats
+from open_webui.models.notes import Notes, NoteUpdateForm
+from open_webui.utils.redis import (
     get_sentinels_from_env,
     get_sentinel_url_from_env,
 )
 
-from backend.open_webui.env import (
+from open_webui.env import (
     ENABLE_WEBSOCKET_SUPPORT,
     WEBSOCKET_MANAGER,
     WEBSOCKET_REDIS_URL,
@@ -28,14 +28,14 @@ from backend.open_webui.env import (
     WEBSOCKET_SENTINEL_HOSTS,
     REDIS_KEY_PREFIX,
 )
-from backend.open_webui.utils.auth import decode_token
-from backend.open_webui.socket.utils import RedisDict, RedisLock, YdocManager
-from backend.open_webui.tasks import create_task, stop_item_tasks
-from backend.open_webui.utils.redis import get_redis_connection
-from backend.open_webui.utils.access_control import has_access, get_users_with_access
+from open_webui.utils.auth import decode_token
+from open_webui.socket.utils import RedisDict, RedisLock, YdocManager
+from open_webui.tasks import create_task, stop_item_tasks
+from open_webui.utils.redis import get_redis_connection
+from open_webui.utils.access_control import has_access, get_users_with_access
 
 
-from backend.open_webui.env import (
+from open_webui.env import (
     GLOBAL_LOG_LEVEL,
     SRC_LOG_LEVELS,
 )

--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -1,7 +1,7 @@
 import json
 import uuid
-from backend.open_webui.utils.redis import get_redis_connection
-from backend.open_webui.env import REDIS_KEY_PREFIX
+from open_webui.utils.redis import get_redis_connection
+from open_webui.env import REDIS_KEY_PREFIX
 from typing import Optional, List, Tuple
 import pycrdt as Y
 

--- a/backend/open_webui/storage/provider.py
+++ b/backend/open_webui/storage/provider.py
@@ -9,7 +9,7 @@ from typing import BinaryIO, Tuple, Dict
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
-from backend.open_webui.config import (
+from open_webui.config import (
     S3_ACCESS_KEY_ID,
     S3_BUCKET_NAME,
     S3_ENDPOINT_URL,
@@ -29,11 +29,11 @@ from backend.open_webui.config import (
 )
 from google.cloud import storage
 from google.cloud.exceptions import GoogleCloudError, NotFound
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.constants import ERROR_MESSAGES
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
 from azure.core.exceptions import ResourceNotFoundError
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -8,7 +8,7 @@ from redis.asyncio import Redis
 from fastapi import Request
 from typing import Dict, List, Optional
 
-from backend.open_webui.env import SRC_LOG_LEVELS, REDIS_KEY_PREFIX
+from open_webui.env import SRC_LOG_LEVELS, REDIS_KEY_PREFIX
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/test/__init__.py
+++ b/backend/open_webui/test/__init__.py
@@ -1,0 +1,24 @@
+"""Test package initialization utilities."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the backend directory is importable so ``open_webui`` can be resolved
+# when running the test suite directly from the repository root.
+backend_dir = Path(__file__).resolve().parents[2]
+if str(backend_dir) not in sys.path:
+    sys.path.insert(0, str(backend_dir))
+
+# Expose the ``test`` package alias to maintain compatibility with modules
+# importing ``test.util`` helpers.
+sys.modules.setdefault("test", sys.modules[__name__])
+try:
+    sys.modules.setdefault("test.util", sys.modules[f"{__name__}.util"])
+except KeyError:
+    # Lazily import util helpers if they have not been loaded yet.
+    import importlib
+
+    sys.modules.setdefault(
+        "test.util", importlib.import_module(f"{__name__}.util")
+    )

--- a/backend/open_webui/test/apps/webui/storage/test_provider.py
+++ b/backend/open_webui/test/apps/webui/storage/test_provider.py
@@ -4,7 +4,7 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
-from backend.open_webui.storage import provider
+from open_webui.storage import provider
 from gcp_storage_emulator.server import create_server
 from google.cloud import storage
 from azure.storage.blob import BlobServiceClient, ContainerClient, BlobClient

--- a/backend/open_webui/test/util/test_redis.py
+++ b/backend/open_webui/test/util/test_redis.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
 import redis
-from backend.open_webui.utils.redis import (
+from open_webui.utils.redis import (
     SentinelRedisProxy,
     parse_redis_service_url,
     get_redis_connection,

--- a/backend/open_webui/utils/access_control.py
+++ b/backend/open_webui/utils/access_control.py
@@ -1,9 +1,9 @@
 from typing import Optional, Set, Union, List, Dict, Any
-from backend.open_webui.models.users import Users, UserModel
-from backend.open_webui.models.groups import Groups
+from open_webui.models.users import Users, UserModel
+from open_webui.models.groups import Groups
 
 
-from backend.open_webui.config import DEFAULT_USER_PERMISSIONS
+from open_webui.config import DEFAULT_USER_PERMISSIONS
 import json
 
 

--- a/backend/open_webui/utils/audit.py
+++ b/backend/open_webui/utils/audit.py
@@ -24,9 +24,9 @@ from asgiref.typing import (
 from loguru import logger
 from starlette.requests import Request
 
-from backend.open_webui.env import AUDIT_LOG_LEVEL, MAX_BODY_LOG_SIZE
-from backend.open_webui.utils.auth import get_current_user, get_http_authorization_cred
-from backend.open_webui.models.users import UserModel
+from open_webui.env import AUDIT_LOG_LEVEL, MAX_BODY_LOG_SIZE
+from open_webui.utils.auth import get_current_user, get_http_authorization_cred
+from open_webui.models.users import UserModel
 
 
 if TYPE_CHECKING:

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -21,11 +21,11 @@ from typing import Optional, Union, List, Dict
 
 from opentelemetry import trace
 
-from backend.open_webui.models.users import Users
+from open_webui.models.users import Users
 
-from backend.open_webui.constants import ERROR_MESSAGES
+from open_webui.constants import ERROR_MESSAGES
 
-from backend.open_webui.env import (
+from open_webui.env import (
     OFFLINE_MODE,
     LICENSE_BLOB,
     pk,

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -14,48 +14,48 @@ from fastapi import Request, status
 from starlette.responses import Response, StreamingResponse, JSONResponse
 
 
-from backend.open_webui.models.users import UserModel
+from open_webui.models.users import UserModel
 
-from backend.open_webui.socket.main import (
+from open_webui.socket.main import (
     sio,
     get_event_call,
     get_event_emitter,
 )
-from backend.open_webui.functions import generate_function_chat_completion
+from open_webui.functions import generate_function_chat_completion
 
-from backend.open_webui.routers.openai import (
+from open_webui.routers.openai import (
     generate_chat_completion as generate_openai_chat_completion,
 )
 
-from backend.open_webui.routers.ollama import (
+from open_webui.routers.ollama import (
     generate_chat_completion as generate_ollama_chat_completion,
 )
 
-from backend.open_webui.routers.pipelines import (
+from open_webui.routers.pipelines import (
     process_pipeline_inlet_filter,
     process_pipeline_outlet_filter,
 )
 
-from backend.open_webui.models.functions import Functions
-from backend.open_webui.models.models import Models
+from open_webui.models.functions import Functions
+from open_webui.models.models import Models
 
 
-from backend.open_webui.utils.plugin import (
+from open_webui.utils.plugin import (
     load_function_module_by_id,
     get_function_module_from_cache,
 )
-from backend.open_webui.utils.models import get_all_models, check_model_access
-from backend.open_webui.utils.payload import convert_payload_openai_to_ollama
-from backend.open_webui.utils.response import (
+from open_webui.utils.models import get_all_models, check_model_access
+from open_webui.utils.payload import convert_payload_openai_to_ollama
+from open_webui.utils.response import (
     convert_response_ollama_to_openai,
     convert_streaming_response_ollama_to_openai,
 )
-from backend.open_webui.utils.filter import (
+from open_webui.utils.filter import (
     get_sorted_filter_ids,
     process_filter_functions,
 )
 
-from backend.open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL, BYPASS_MODEL_ACCESS_CONTROL
+from open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL, BYPASS_MODEL_ACCESS_CONTROL
 
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)

--- a/backend/open_webui/utils/code_interpreter.py
+++ b/backend/open_webui/utils/code_interpreter.py
@@ -8,7 +8,7 @@ import aiohttp
 import websockets
 from pydantic import BaseModel
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 logger = logging.getLogger(__name__)
 logger.setLevel(SRC_LOG_LEVELS["MAIN"])

--- a/backend/open_webui/utils/embeddings.py
+++ b/backend/open_webui/utils/embeddings.py
@@ -3,20 +3,20 @@ import logging
 import sys
 
 from fastapi import Request
-from backend.open_webui.models.users import UserModel
-from backend.open_webui.models.models import Models
-from backend.open_webui.utils.models import check_model_access
-from backend.open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL, BYPASS_MODEL_ACCESS_CONTROL
+from open_webui.models.users import UserModel
+from open_webui.models.models import Models
+from open_webui.utils.models import check_model_access
+from open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL, BYPASS_MODEL_ACCESS_CONTROL
 
-from backend.open_webui.routers.openai import embeddings as openai_embeddings
-from backend.open_webui.routers.ollama import (
+from open_webui.routers.openai import embeddings as openai_embeddings
+from open_webui.routers.ollama import (
     embeddings as ollama_embeddings,
     GenerateEmbeddingsForm,
 )
 
 
-from backend.open_webui.utils.payload import convert_embedding_payload_openai_to_ollama
-from backend.open_webui.utils.response import convert_embedding_response_ollama_to_openai
+from open_webui.utils.payload import convert_embedding_payload_openai_to_ollama
+from open_webui.utils.response import convert_embedding_response_ollama_to_openai
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)

--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -1,4 +1,4 @@
-from backend.open_webui.routers.images import (
+from open_webui.routers.images import (
     load_b64_image_data,
     upload_image,
 )
@@ -11,7 +11,7 @@ from fastapi import (
     UploadFile,
 )
 
-from backend.open_webui.routers.files import upload_file_handler
+from open_webui.routers.files import upload_file_handler
 
 import mimetypes
 import base64

--- a/backend/open_webui/utils/filter.py
+++ b/backend/open_webui/utils/filter.py
@@ -1,12 +1,12 @@
 import inspect
 import logging
 
-from backend.open_webui.utils.plugin import (
+from open_webui.utils.plugin import (
     load_function_module_by_id,
     get_function_module_from_cache,
 )
-from backend.open_webui.models.functions import Functions
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.models.functions import Functions
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MAIN"])

--- a/backend/open_webui/utils/images/comfyui.py
+++ b/backend/open_webui/utils/images/comfyui.py
@@ -7,7 +7,7 @@ import urllib.request
 from typing import Optional
 
 import websocket  # NOTE: websocket-client (https://github.com/websocket-client/websocket-client)
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 from pydantic import BaseModel
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -24,57 +24,57 @@ from fastapi.responses import HTMLResponse
 from starlette.responses import Response, StreamingResponse, JSONResponse
 
 
-from backend.open_webui.models.oauth_sessions import OAuthSessions
-from backend.open_webui.models.chats import Chats
-from backend.open_webui.models.folders import Folders
-from backend.open_webui.models.users import Users
-from backend.open_webui.socket.main import (
+from open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.chats import Chats
+from open_webui.models.folders import Folders
+from open_webui.models.users import Users
+from open_webui.socket.main import (
     get_event_call,
     get_event_emitter,
     get_active_status_by_user_id,
 )
-from backend.open_webui.routers.tasks import (
+from open_webui.routers.tasks import (
     generate_queries,
     generate_title,
     generate_follow_ups,
     generate_image_prompt,
     generate_chat_tags,
 )
-from backend.open_webui.routers.retrieval import process_web_search, SearchForm
-from backend.open_webui.routers.images import (
+from open_webui.routers.retrieval import process_web_search, SearchForm
+from open_webui.routers.images import (
     load_b64_image_data,
     image_generations,
     GenerateImageForm,
     upload_image,
 )
-from backend.open_webui.routers.pipelines import (
+from open_webui.routers.pipelines import (
     process_pipeline_inlet_filter,
     process_pipeline_outlet_filter,
 )
-from backend.open_webui.routers.memories import query_memory, QueryMemoryForm
+from open_webui.routers.memories import query_memory, QueryMemoryForm
 
-from backend.open_webui.utils.webhook import post_webhook
-from backend.open_webui.utils.files import (
+from open_webui.utils.webhook import post_webhook
+from open_webui.utils.files import (
     get_audio_url_from_base64,
     get_file_url_from_base64,
     get_image_url_from_base64,
 )
 
 
-from backend.open_webui.models.users import UserModel
-from backend.open_webui.models.functions import Functions
-from backend.open_webui.models.models import Models
+from open_webui.models.users import UserModel
+from open_webui.models.functions import Functions
+from open_webui.models.models import Models
 
-from backend.open_webui.retrieval.utils import get_sources_from_items
+from open_webui.retrieval.utils import get_sources_from_items
 
 
-from backend.open_webui.utils.chat import generate_chat_completion
-from backend.open_webui.utils.task import (
+from open_webui.utils.chat import generate_chat_completion
+from open_webui.utils.task import (
     get_task_model_id,
     rag_template,
     tools_function_calling_generation_template,
 )
-from backend.open_webui.utils.misc import (
+from open_webui.utils.misc import (
     deep_update,
     get_message_list,
     add_or_update_system_message,
@@ -85,24 +85,24 @@ from backend.open_webui.utils.misc import (
     prepend_to_first_user_message_content,
     convert_logit_bias_input_to_json,
 )
-from backend.open_webui.utils.tools import get_tools
-from backend.open_webui.utils.plugin import load_function_module_by_id
-from backend.open_webui.utils.filter import (
+from open_webui.utils.tools import get_tools
+from open_webui.utils.plugin import load_function_module_by_id
+from open_webui.utils.filter import (
     get_sorted_filter_ids,
     process_filter_functions,
 )
-from backend.open_webui.utils.code_interpreter import execute_code_jupyter
-from backend.open_webui.utils.payload import apply_system_prompt_to_body
-from backend.open_webui.utils.mcp.client import MCPClient
+from open_webui.utils.code_interpreter import execute_code_jupyter
+from open_webui.utils.payload import apply_system_prompt_to_body
+from open_webui.utils.mcp.client import MCPClient
 
 
-from backend.open_webui.config import (
+from open_webui.config import (
     CACHE_DIR,
     DEFAULT_TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE,
     DEFAULT_CODE_INTERPRETER_PROMPT,
     CODE_INTERPRETER_BLOCKED_MODULES,
 )
-from backend.open_webui.env import (
+from open_webui.env import (
     SRC_LOG_LEVELS,
     GLOBAL_LOG_LEVEL,
     CHAT_RESPONSE_STREAM_DELTA_CHUNK_SIZE,
@@ -111,7 +111,7 @@ from backend.open_webui.env import (
     ENABLE_REALTIME_CHAT_SAVE,
     ENABLE_QUERIES_CACHE,
 )
-from backend.open_webui.constants import TASKS
+from open_webui.constants import TASKS
 
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -11,7 +11,7 @@ import json
 
 
 import collections.abc
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MAIN"])

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -6,28 +6,28 @@ import sys
 from aiocache import cached
 from fastapi import Request
 
-from backend.open_webui.routers import openai, ollama
-from backend.open_webui.functions import get_function_models
+from open_webui.routers import openai, ollama
+from open_webui.functions import get_function_models
 
 
-from backend.open_webui.models.functions import Functions
-from backend.open_webui.models.models import Models
+from open_webui.models.functions import Functions
+from open_webui.models.models import Models
 
 
-from backend.open_webui.utils.plugin import (
+from open_webui.utils.plugin import (
     load_function_module_by_id,
     get_function_module_from_cache,
 )
-from backend.open_webui.utils.access_control import has_access
+from open_webui.utils.access_control import has_access
 
 
-from backend.open_webui.config import (
+from open_webui.config import (
     BYPASS_ADMIN_ACCESS_CONTROL,
     DEFAULT_ARENA_MODEL,
 )
 
-from backend.open_webui.env import BYPASS_MODEL_ACCESS_CONTROL, SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
-from backend.open_webui.models.users import UserModel
+from open_webui.env import BYPASS_MODEL_ACCESS_CONTROL, SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
+from open_webui.models.users import UserModel
 
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -26,13 +26,13 @@ from starlette.responses import RedirectResponse
 from typing import Optional
 
 
-from backend.open_webui.models.auths import Auths
-from backend.open_webui.models.oauth_sessions import OAuthSessions
-from backend.open_webui.models.users import Users
+from open_webui.models.auths import Auths
+from open_webui.models.oauth_sessions import OAuthSessions
+from open_webui.models.users import Users
 
 
-from backend.open_webui.models.groups import Groups, GroupModel, GroupUpdateForm, GroupForm
-from backend.open_webui.config import (
+from open_webui.models.groups import Groups, GroupModel, GroupUpdateForm, GroupForm
+from open_webui.config import (
     DEFAULT_USER_ROLE,
     ENABLE_OAUTH_SIGNUP,
     OAUTH_MERGE_ACCOUNTS_BY_EMAIL,
@@ -55,8 +55,8 @@ from backend.open_webui.config import (
     JWT_EXPIRES_IN,
     AppConfig,
 )
-from backend.open_webui.constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
-from backend.open_webui.env import (
+from open_webui.constants import ERROR_MESSAGES, WEBHOOK_MESSAGES
+from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     WEBUI_NAME,
     WEBUI_AUTH_COOKIE_SAME_SITE,
@@ -64,9 +64,9 @@ from backend.open_webui.env import (
     ENABLE_OAUTH_ID_TOKEN_COOKIE,
     OAUTH_CLIENT_INFO_ENCRYPTION_KEY,
 )
-from backend.open_webui.utils.misc import parse_duration
-from backend.open_webui.utils.auth import get_password_hash, create_token
-from backend.open_webui.utils.webhook import post_webhook
+from open_webui.utils.misc import parse_duration
+from open_webui.utils.auth import get_password_hash, create_token
+from open_webui.utils.webhook import post_webhook
 
 from mcp.shared.auth import (
     OAuthClientMetadata,
@@ -83,7 +83,7 @@ class OAuthClientInformationFull(OAuthClientMetadata):
     client_secret_expires_at: int | None = None
 
 
-from backend.open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
+from open_webui.env import SRC_LOG_LEVELS, GLOBAL_LOG_LEVEL
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -1,5 +1,5 @@
-from backend.open_webui.utils.task import prompt_template, prompt_variables_template
-from backend.open_webui.utils.misc import (
+from open_webui.utils.task import prompt_template, prompt_variables_template
+from open_webui.utils.misc import (
     deep_update,
     add_or_update_system_message,
 )

--- a/backend/open_webui/utils/pdf_generator.py
+++ b/backend/open_webui/utils/pdf_generator.py
@@ -9,8 +9,8 @@ from markdown import markdown
 import site
 from fpdf import FPDF
 
-from backend.open_webui.env import STATIC_DIR, FONTS_DIR
-from backend.open_webui.models.chats import ChatTitleMessagesForm
+from open_webui.env import STATIC_DIR, FONTS_DIR
+from open_webui.models.chats import ChatTitleMessagesForm
 
 
 class PDFGenerator:

--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -7,9 +7,9 @@ import types
 import tempfile
 import logging
 
-from backend.open_webui.env import SRC_LOG_LEVELS, PIP_OPTIONS, PIP_PACKAGE_INDEX_OPTIONS
-from backend.open_webui.models.functions import Functions
-from backend.open_webui.models.tools import Tools
+from open_webui.env import SRC_LOG_LEVELS, PIP_OPTIONS, PIP_PACKAGE_INDEX_OPTIONS
+from open_webui.models.functions import Functions
+from open_webui.models.tools import Tools
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MAIN"])

--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -5,7 +5,9 @@ import logging
 
 import redis
 
-from backend.open_webui.env import REDIS_SENTINEL_MAX_RETRY_COUNT
+from open_webui.env import REDIS_SENTINEL_MAX_RETRY_COUNT
+
+MAX_RETRY_COUNT = REDIS_SENTINEL_MAX_RETRY_COUNT
 
 log = logging.getLogger(__name__)
 

--- a/backend/open_webui/utils/response.py
+++ b/backend/open_webui/utils/response.py
@@ -1,6 +1,6 @@
 import json
 from uuid import uuid4
-from backend.open_webui.utils.misc import (
+from open_webui.utils.misc import (
     openai_chat_chunk_message_template,
     openai_chat_completion_message_template,
 )

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -6,10 +6,10 @@ from typing import Optional, Any
 import uuid
 
 
-from backend.open_webui.utils.misc import get_last_user_message, get_messages_content
+from open_webui.utils.misc import get_last_user_message, get_messages_content
 
-from backend.open_webui.env import SRC_LOG_LEVELS
-from backend.open_webui.config import DEFAULT_RAG_TEMPLATE
+from open_webui.env import SRC_LOG_LEVELS
+from open_webui.config import DEFAULT_RAG_TEMPLATE
 
 
 log = logging.getLogger(__name__)

--- a/backend/open_webui/utils/telemetry/instrumentors.py
+++ b/backend/open_webui/utils/telemetry/instrumentors.py
@@ -26,9 +26,9 @@ from requests import PreparedRequest, Response
 from sqlalchemy import Engine
 from fastapi import status
 
-from backend.open_webui.utils.telemetry.constants import SPAN_REDIS_TYPE, SpanAttributes
+from open_webui.utils.telemetry.constants import SPAN_REDIS_TYPE, SpanAttributes
 
-from backend.open_webui.env import SRC_LOG_LEVELS
+from open_webui.env import SRC_LOG_LEVELS
 
 logger = logging.getLogger(__name__)
 logger.setLevel(SRC_LOG_LEVELS["MAIN"])

--- a/backend/open_webui/utils/telemetry/logs.py
+++ b/backend/open_webui/utils/telemetry/logs.py
@@ -11,7 +11,7 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import (
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from backend.open_webui.env import (
+from open_webui.env import (
     OTEL_SERVICE_NAME,
     OTEL_LOGS_EXPORTER_OTLP_ENDPOINT,
     OTEL_LOGS_EXPORTER_OTLP_INSECURE,

--- a/backend/open_webui/utils/telemetry/metrics.py
+++ b/backend/open_webui/utils/telemetry/metrics.py
@@ -37,7 +37,7 @@ from opentelemetry.sdk.metrics.export import (
 )
 from opentelemetry.sdk.resources import Resource
 
-from backend.open_webui.env import (
+from open_webui.env import (
     OTEL_SERVICE_NAME,
     OTEL_METRICS_EXPORTER_OTLP_ENDPOINT,
     OTEL_METRICS_BASIC_AUTH_USERNAME,
@@ -45,8 +45,8 @@ from backend.open_webui.env import (
     OTEL_METRICS_OTLP_SPAN_EXPORTER,
     OTEL_METRICS_EXPORTER_OTLP_INSECURE,
 )
-from backend.open_webui.socket.main import get_active_user_ids
-from backend.open_webui.models.users import Users
+from open_webui.socket.main import get_active_user_ids
+from open_webui.models.users import Users
 
 _EXPORT_INTERVAL_MILLIS = 10_000  # 10 seconds
 

--- a/backend/open_webui/utils/telemetry/setup.py
+++ b/backend/open_webui/utils/telemetry/setup.py
@@ -11,9 +11,9 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from sqlalchemy import Engine
 from base64 import b64encode
 
-from backend.open_webui.utils.telemetry.instrumentors import Instrumentor
-from backend.open_webui.utils.telemetry.metrics import setup_metrics
-from backend.open_webui.env import (
+from open_webui.utils.telemetry.instrumentors import Instrumentor
+from open_webui.utils.telemetry.metrics import setup_metrics
+from open_webui.env import (
     OTEL_SERVICE_NAME,
     OTEL_EXPORTER_OTLP_ENDPOINT,
     OTEL_EXPORTER_OTLP_INSECURE,

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -34,10 +34,10 @@ from langchain_core.utils.function_calling import (
 )
 
 
-from backend.open_webui.models.tools import Tools
-from backend.open_webui.models.users import UserModel
-from backend.open_webui.utils.plugin import load_tool_module_by_id
-from backend.open_webui.env import (
+from open_webui.models.tools import Tools
+from open_webui.models.users import UserModel
+from open_webui.utils.plugin import load_tool_module_by_id
+from open_webui.env import (
     SRC_LOG_LEVELS,
     AIOHTTP_CLIENT_TIMEOUT,
     AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER_DATA,

--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -2,8 +2,8 @@ import json
 import logging
 import aiohttp
 
-from backend.open_webui.config import WEBUI_FAVICON_URL
-from backend.open_webui.env import SRC_LOG_LEVELS, VERSION
+from open_webui.config import WEBUI_FAVICON_URL
+from open_webui.env import SRC_LOG_LEVELS, VERSION
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["WEBHOOK"])

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,17 @@
+"""Expose backend Open WebUI tests as a top-level ``test`` package."""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parents[1]
+_backend_dir = _repo_root / "backend"
+if str(_backend_dir) not in sys.path:
+    sys.path.insert(0, str(_backend_dir))
+
+_backend_tests = importlib.import_module("backend.open_webui.test")
+# Ensure common subpackages remain importable via ``test.util`` and similar paths.
+sys.modules.setdefault("test.util", importlib.import_module("backend.open_webui.test.util"))
+
+__all__ = getattr(_backend_tests, "__all__", ())


### PR DESCRIPTION
## Summary
- replace `backend.open_webui` import paths with the canonical `open_webui` package across the backend codebase
- expose compatibility hooks so the backend package can be imported as `open_webui` in both editable-source and installed-package modes
- add test harness helpers and constants to keep the test suite importing through the new package name

## Testing
- `PYTHONPATH=backend pytest backend/open_webui/test/util/test_redis.py -k test_parse_redis_service_url_valid --maxfail=1`
- `pytest --maxfail=1` *(fails: missing optional test dependencies such as moto and unresolved `test.util` alias in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db75aae5f8833284aa452ad7bb0c68