### PR TITLE
Fix peewee migration cleanup and add regression test

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -53,7 +53,7 @@ class JSONField(types.TypeDecorator):
 # Workaround to handle the peewee migration
 # This is required to ensure the peewee migration is handled before the alembic migration
 def handle_peewee_migration(DATABASE_URL):
-    # db = None
+    db = None
     try:
         # Replace the postgresql:// with postgres:// to handle the peewee migration
         db = register_connection(DATABASE_URL.replace("postgresql://", "postgres://"))
@@ -70,11 +70,12 @@ def handle_peewee_migration(DATABASE_URL):
         raise
     finally:
         # Properly closing the database connection
-        if db and not db.is_closed():
+        if db is not None and not db.is_closed():
             db.close()
 
         # Assert if db connection has been closed
-        assert db.is_closed(), "Database connection is still open."
+        if db is not None:
+            assert db.is_closed(), "Database connection is still open."
 
 
 handle_peewee_migration(DATABASE_URL)

--- a/backend/open_webui/test/internal/test_db.py
+++ b/backend/open_webui/test/internal/test_db.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+
+import pytest
+from peewee import OperationalError
+
+
+def test_handle_peewee_migration_propagates_operational_error(monkeypatch):
+    """Ensure peewee migration failures re-raise the original OperationalError."""
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    if "open_webui.internal.db" in sys.modules:
+        del sys.modules["open_webui.internal.db"]
+
+    db_module = importlib.import_module("open_webui.internal.db")
+
+    def failing_register_connection(_):
+        raise OperationalError("bad connection")
+
+    monkeypatch.setattr(db_module, "register_connection", failing_register_connection)
+
+    with pytest.raises(OperationalError) as excinfo:
+        db_module.handle_peewee_migration("postgresql://user:pass@localhost/db")
+
+    assert "bad connection" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- initialize the peewee migration helper with a safe default and guard its cleanup logic
- add a regression test that verifies OperationalError propagation when the peewee connection fails

## Testing
- pytest backend/open_webui/test/internal/test_db.py

------
https://chatgpt.com/codex/tasks/task_e_68de18e0eac08332ab2a11d50477b098