### PR TITLE
Normalize PostgreSQL URLs for peewee migrations

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -3,6 +3,7 @@ import json
 import logging
 from contextlib import contextmanager
 from typing import Any, Optional
+from urllib.parse import urlparse, urlunparse
 
 from open_webui.internal.wrappers import register_connection
 from open_webui.env import (
@@ -52,11 +53,31 @@ class JSONField(types.TypeDecorator):
 
 # Workaround to handle the peewee migration
 # This is required to ensure the peewee migration is handled before the alembic migration
+def _normalize_postgres_url(url: str) -> str:
+    """Normalize SQLAlchemy PostgreSQL URLs for peewee compatibility."""
+
+    parsed_url = urlparse(url)
+
+    if parsed_url.scheme and parsed_url.scheme.lower().startswith("postgresql"):
+        return urlunparse(
+            (
+                "postgres",
+                parsed_url.netloc,
+                parsed_url.path,
+                parsed_url.params,
+                parsed_url.query,
+                parsed_url.fragment,
+            )
+        )
+
+    return url
+
+
 def handle_peewee_migration(DATABASE_URL):
     db = None
     try:
-        # Replace the postgresql:// with postgres:// to handle the peewee migration
-        db = register_connection(DATABASE_URL.replace("postgresql://", "postgres://"))
+        # Normalize PostgreSQL URLs (e.g. postgresql+psycopg2://) for peewee compatibility
+        db = register_connection(_normalize_postgres_url(DATABASE_URL))
         migrate_dir = OPEN_WEBUI_DIR / "internal" / "migrations"
         router = Router(db, logger=log, migrate_dir=migrate_dir)
         router.run()

--- a/backend/open_webui/test/internal/test_db.py
+++ b/backend/open_webui/test/internal/test_db.py
@@ -5,6 +5,27 @@ import pytest
 from peewee import OperationalError
 
 
+class DummyDB:
+    def __init__(self):
+        self._closed = False
+
+    def close(self):
+        self._closed = True
+
+    def is_closed(self):
+        return self._closed
+
+
+class DummyRouter:
+    def __init__(self, db, logger, migrate_dir):
+        self.db = db
+        self.logger = logger
+        self.migrate_dir = migrate_dir
+
+    def run(self):
+        return None
+
+
 def test_handle_peewee_migration_propagates_operational_error(monkeypatch):
     """Ensure peewee migration failures re-raise the original OperationalError."""
     monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
@@ -23,3 +44,49 @@ def test_handle_peewee_migration_propagates_operational_error(monkeypatch):
         db_module.handle_peewee_migration("postgresql://user:pass@localhost/db")
 
     assert "bad connection" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "input_url,expected_url",
+    [
+        (
+            "postgresql://user:pass@localhost:5432/db?sslmode=require",
+            "postgres://user:pass@localhost:5432/db?sslmode=require",
+        ),
+        (
+            "postgresql+psycopg2://user:pass@localhost/db",
+            "postgres://user:pass@localhost/db",
+        ),
+    ],
+)
+def test_handle_peewee_migration_normalizes_postgres_variants(
+    monkeypatch, input_url, expected_url
+):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    # Ensure a fresh import so the patched dependencies are used.
+    if "open_webui.internal.db" in sys.modules:
+        del sys.modules["open_webui.internal.db"]
+
+    captured_urls = []
+
+    def fake_register_connection(url):
+        captured_urls.append(url)
+        return DummyDB()
+
+    monkeypatch.setattr(
+        "open_webui.internal.wrappers.register_connection", fake_register_connection
+    )
+    monkeypatch.setattr("peewee_migrate.Router", DummyRouter)
+
+    db_module = importlib.import_module("open_webui.internal.db")
+
+    # Ignore the import-time initialization call.
+    captured_urls.clear()
+
+    monkeypatch.setattr(db_module, "Router", DummyRouter)
+    monkeypatch.setattr(db_module, "register_connection", fake_register_connection)
+
+    db_module.handle_peewee_migration(input_url)
+
+    assert captured_urls == [expected_url]


### PR DESCRIPTION
## Summary
- normalize PostgreSQL dialect variants before registering the peewee connection
- add regression tests covering postgresql and postgresql+psycopg2 URL variants

## Testing
- pytest backend/open_webui/test/internal/test_db.py

------
https://chatgpt.com/codex/tasks/task_e_68de3b6eeea883328e4083619b91f612