### PR TITLE
Annotate database handle initialization for peewee migration

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -74,7 +74,7 @@ def _normalize_postgres_url(url: str) -> str:
 
 
 def handle_peewee_migration(DATABASE_URL):
-    db = None
+    db: Optional[Any] = None
     try:
         # Normalize PostgreSQL URLs (e.g. postgresql+psycopg2://) for peewee compatibility
         db = register_connection(_normalize_postgres_url(DATABASE_URL))


### PR DESCRIPTION
## Summary
- annotate the peewee migration helper's database handle as optional to reflect failure-path initialization

## Testing
- pytest backend/open_webui/test/internal/test_db.py::test_handle_peewee_migration_propagates_operational_error

------
https://chatgpt.com/codex/tasks/task_e_68de408ec5e48332bf17594520a96b06