### PR TITLE
Normalize PostgreSQL URLs for peewee migrations

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -53,22 +53,16 @@ class JSONField(types.TypeDecorator):
 
 # Workaround to handle the peewee migration
 # This is required to ensure the peewee migration is handled before the alembic migration
+
+
 def _normalize_postgres_url(url: str) -> str:
     """Normalize SQLAlchemy PostgreSQL URLs for peewee compatibility."""
 
     parsed_url = urlparse(url)
 
     if parsed_url.scheme and parsed_url.scheme.lower().startswith("postgresql"):
-        return urlunparse(
-            (
-                "postgres",
-                parsed_url.netloc,
-                parsed_url.path,
-                parsed_url.params,
-                parsed_url.query,
-                parsed_url.fragment,
-            )
-        )
+        normalized_url = parsed_url._replace(scheme="postgres")
+        return urlunparse(normalized_url)
 
     return url
 

--- a/backend/open_webui/test/internal/test_db.py
+++ b/backend/open_webui/test/internal/test_db.py
@@ -90,3 +90,45 @@ def test_handle_peewee_migration_normalizes_postgres_variants(
     db_module.handle_peewee_migration(input_url)
 
     assert captured_urls == [expected_url]
+
+
+@pytest.mark.parametrize(
+    "database_url,expected_url",
+    [
+        (
+            "postgresql://user:pass@localhost:5432/db?sslmode=require",
+            "postgres://user:pass@localhost:5432/db?sslmode=require",
+        ),
+        (
+            "postgresql+psycopg2://user:pass@localhost/db",
+            "postgres://user:pass@localhost/db",
+        ),
+    ],
+)
+def test_import_initialization_accepts_postgres_variants(monkeypatch, database_url, expected_url):
+    """Import-time initialization should accept PostgreSQL dialect variants."""
+
+    monkeypatch.setenv("DATABASE_URL", database_url)
+
+    env_module = importlib.import_module("open_webui.env")
+    monkeypatch.setattr(env_module, "DATABASE_URL", database_url, raising=False)
+
+    captured_urls = []
+
+    def fake_register_connection(url):
+        captured_urls.append(url)
+        return DummyDB()
+
+    monkeypatch.setattr(
+        "open_webui.internal.wrappers.register_connection", fake_register_connection
+    )
+    monkeypatch.setattr("peewee_migrate.Router", DummyRouter)
+    monkeypatch.setattr("sqlalchemy.create_engine", lambda *_, **__: object())
+    monkeypatch.setattr("sqlalchemy.event.listen", lambda *_, **__: None)
+
+    if "open_webui.internal.db" in sys.modules:
+        del sys.modules["open_webui.internal.db"]
+
+    importlib.import_module("open_webui.internal.db")
+
+    assert captured_urls == [expected_url]


### PR DESCRIPTION
## Summary
- normalize PostgreSQL database URLs using URL parsing so peewee always receives a postgres:// DSN
- ensure peewee migration initialization handles PostgreSQL dialect variants at import-time through tests

## Testing
- pytest backend/open_webui/test/internal/test_db.py

------
https://chatgpt.com/codex/tasks/task_e_68de408ee7748332b17b83936512dfdc